### PR TITLE
Add check that row is actually a plain object

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const convert = (converters, value) => {
 };
 
 const keyConvert = (converters) => (row) => {
-    if (!row) return row;
+    if (!row || row.constructor.name.toLowerCase() !== "object") return row;
 
     const result = {};
 


### PR DESCRIPTION
...before doing key conversion.

This solves the problem when using  `.returning()` with a single column name (e.g. `.returning('id')`, which will not return an array of objects but instead an array of ids. 

Fixes #1 