### PR TITLE
Optional query context is now passed to callback functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ The two knex config options this library overrides are `postProcessResponse` and
 
 ## New options
 
-#### beforePostProcessResponse (value: string) => string
+#### beforePostProcessResponse (value: string, queryContext: object) => string
 
 A function which runs before modifications made by this library if needed.
 
-#### beforeWrapIdentifier (value: string) => string
+#### beforeWrapIdentifier (value: string, queryContext: object) => string
 
 A function which runs before modifications made by this library if needed.
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const getConverters = require('./get-converters');
 
+const noOperation = v => v;
+
 const convert = (converters, value) => {
     let result = value;
 
@@ -23,11 +25,11 @@ const keyConvert = (converters) => (row) => {
     return result;
 };
 
-const postProcessResponse = (converters, before, after) => (raw) => {
+const postProcessResponse = (converters, before, after) => (raw, queryContext = {}) => {
     let result = raw;
 
     if (typeof before === 'function') {
-        result = before(result);
+        result = before(result, queryContext);
     }
 
     if (Array.isArray(result)) {
@@ -37,23 +39,23 @@ const postProcessResponse = (converters, before, after) => (raw) => {
     }
 
     if (typeof after === 'function') {
-        result = after(result);
+        result = after(result, queryContext);
     }
 
     return result;
 };
 
-const wrapIdentifier = (converters, before, after) => (value, origImpl) => {
+const wrapIdentifier = (converters, before, after) => (value, origImpl, queryContext = {}) => {
     let result = value;
 
     if (typeof before === 'function') {
-        result = before(result);
+        result = before(result, noOperation, queryContext);
     }
 
     result = convert(converters, result);
 
     if (typeof after === 'function') {
-        result = after(result, origImpl);
+        result = after(result, origImpl, queryContext);
     } else {
         result = origImpl(result);
     }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 const getConverters = require('./get-converters');
 
-const noOperation = v => v;
-
 const convert = (converters, value) => {
     let result = value;
 
@@ -49,7 +47,7 @@ const wrapIdentifier = (converters, before, after) => (value, origImpl, queryCon
     let result = value;
 
     if (typeof before === 'function') {
-        result = before(result, noOperation, queryContext);
+        result = before(result, queryContext);
     }
 
     result = convert(converters, result);


### PR DESCRIPTION
Knex callbacks have an optional last parameter to provide some context about the query. This allows the hooks to be dynamic based on the context. More info: https://github.com/tgriesser/knex/issues/2268

This PR allows the queryContext to pass through the callbacks.