### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,15 +63,20 @@ const wrapIdentifier = (converters, before, after) => (value, origImpl, queryCon
 
 const keyConvert = (converters) => (row) => {
     if (!(row instanceof Object)) return row;
+    return recursiveKeyConvert(row, converters);
+};
 
-    const result = {};
-
+function recursiveKeyConvert(row, converters) {
+    const result = {}
     for (const key of Object.keys(row)) {
         const converted = convert(converters, key);
-        result[converted] = row[key];
+        if (row[key] instanceof Object) {
+            result[converted] = recursiveKeyConvert(row[key], converters)
+        } else {
+            result[converted] = row[key];
+        }
     }
-
-    return result;
+    return result
 };
 
 const convert = (converters, value) => {


### PR DESCRIPTION
fix for recursive nested objects

Fixed for results with nested objects.

If use MySql JSON features with subqueries, or enabled nestTables option (mysql), now works recursively for all cases.

Example: 

Knex.select()
    .from('user')
    .leftJoin('posts', 'user.id', 'posts.userId')
    .options({ nestTables: true })

result:

{user{....}, posts{...}}
{user{....}, posts{...}}
{user{....}, posts{...}}
